### PR TITLE
修复部分情况下截图是全白透明的bug

### DIFF
--- a/assets/cases/07_capture_texture/textureRenderUtils.js
+++ b/assets/cases/07_capture_texture/textureRenderUtils.js
@@ -10,7 +10,10 @@ cc.Class({
     init () {
         this.label.string = '';
         let texture = new cc.RenderTexture();
-        texture.initWithSize(cc.visibleRect.width, cc.visibleRect.height, cc.gfx.RB_FMT_S8);
+        let {width, height} = cc.visibleRect;
+        width = parseInt(width.toFixed(0));
+        height = parseInt(height.toFixed(0));
+        texture.initWithSize(width, height, cc.gfx.RB_FMT_S8);
         this.camera.targetTexture = texture;
         this.texture = texture;
     },


### PR DESCRIPTION
cc.visibleRect在部分设备返回值为1.00000000001
导致后续计算 data[start + i]=undefined，进而导致截图异常
